### PR TITLE
Maintenance mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Further properties, with defaults, may be modified and are referenced in the [so
 This resource is designed to create-or-remove a file which the health check looks for when determining if it should return a 503 for maintenance mode. 
 
 The following properties are all *optional*:
-- path: The location of the maintenance file, defaults to: `node['nginx_resources']['health']['config']['maintenace_override']`
+- path: The location of the maintenance file, defaults to: `node['nginx_resources']['health']['config']['maintenance_override']`
 - compile\_time: Boolean which determins whether to run the action of _manage_ at compile time.
 - enable\_only\_if: A block which must return true/false determining whether maintenance mode should activated.
 - disable\_only\_if: A block which must return true/false determining whether the maintenance mode should be activated.

--- a/README.md
+++ b/README.md
@@ -179,3 +179,15 @@ The following properties are *required* and have no defaults:
 
 Further properties, with defaults, may be modified and are referenced in the [source](resources/build.rb) file.
 
+### nginx\_resources\_maintenance
+
+This resource is designed to create-or-remove a file which the health check looks for when determining if it should return a 503 for maintenance mode. 
+
+The following properties are all *optional*:
+- path: The location of the maintenance file, defaults to: `node['nginx_resources']['health']['config']['maintenace_override']`
+- compile\_time: Boolean which determins whether to run the action of _manage_ at compile time.
+- enable\_only\_if: A block which must return true/false determining whether maintenance mode should activated.
+- disable\_only\_if: A block which must return true/false determining whether the maintenance mode should be activated.
+
+ Further properties, with defaults, may be modified and are referenced in the [source](resources/maintenance.rb) file.
+

--- a/attributes/module_health.rb
+++ b/attributes/module_health.rb
@@ -3,6 +3,6 @@ default['nginx_resources']['health']['config'].tap do |config|
   config['uri']     = '/nginx_health'
   config['allow']   = ['127.0.0.1']
   config['deny']    = ['all']
-  config['maintenace_override'] = '/var/lib/nginx-maintenace-mode'
+  config['maintenance_override'] = '/var/lib/nginx-maintenance-mode'
   config['access_log'] = true
 end

--- a/attributes/module_lua.rb
+++ b/attributes/module_lua.rb
@@ -32,4 +32,3 @@ default['nginx_resources']['lua']['config'].tap do |config|
   config['init']['includes'] = %w()
   config['init_worker']['includes'] = %w()
 end
-

--- a/recipes/install_source.rb
+++ b/recipes/install_source.rb
@@ -1,7 +1,7 @@
 
 # Build nginx from source
 #
-nginx_resources_source "nginx_default" do
+nginx_resources_source 'nginx_default' do
   source    node['nginx_resources']['source']['url']
   version   node['nginx_resources']['source']['version']
   checksum  node['nginx_resources']['source']['checksum']
@@ -11,4 +11,3 @@ nginx_resources_source "nginx_default" do
     "nginx-#{node['nginx_resources']['source']['version']}"
   )
 end
-

--- a/recipes/module_lua.rb
+++ b/recipes/module_lua.rb
@@ -40,7 +40,7 @@ nginx_resources_config 'lua' do
   configs node['nginx_resources']['lua']['config']
 end
 
-# Patch nginx with lua ssl support 
+# Patch nginx with lua ssl support
 # - https://raw.githubusercontent.com/openresty/lua-nginx-module/ssl-cert-by-lua/patches/nginx-ssl-cert.patch
 source = resources('nginx_resources_source[nginx_default]')
 patch_file = "#{Chef::Config['file_cache_path']}/ngx_lua_ssl.patch"
@@ -53,4 +53,3 @@ execute 'apply_ngx_ssl_lua_patch' do
   not_if  %(patch -p1 --dry-run --reverse --silent < #{patch_file}),
             'cwd' => source.deploy_path
 end
-

--- a/resources/maintenance.rb
+++ b/resources/maintenance.rb
@@ -1,0 +1,135 @@
+# Maintenance resource is designed to enable/disable maintenance mode on the 
+# instance. It also provides facilities to force maintenance mode for the 
+# duration of a Chef run.
+#
+# @example
+# ```ruby
+# nginx_resources_maintenance 'default' do
+#   compile_time true
+#   enable_only_if do
+#     node['attribute_to_enable_maintenance']
+#   end
+#   disable only if do
+#     !node['attribute_to_enable_maintenance'] ||
+#     node['attribute_to_delete_maintenance']
+#   end
+#   action :manage
+# end
+# ```
+resource_name :nginx_resources_maintenance
+
+# Path to the maintenance mode file which is used by the `module_health` recipe
+# @since 0.5.0
+property :path,
+  kind_of: String,
+  default: lazy {
+    node['nginx_resources']['health']['config']['maintenace_override']
+  }
+
+# Whether to apply the resource at compile time
+# @since 0.5.0
+property :compile_time,
+  kind_of: [TrueClass, FalseClass],
+  default: false
+
+# Condition to determine whether to enable maintenance mode
+# @since 0.5.0
+def enable_only_if(&block)
+  set_or_return(:enable_only_if, block, kind_of: Proc)
+end
+
+# Chef event_handler to hook into when enabling
+# @since 0.5.0
+property :enable_event,
+  kind_of: String,
+  default: "converge_start"
+
+# Condition to determine whether to disable maintenance mode
+# @since 0.5.0
+def disable_only_if(&block)
+  set_or_return(:disable_only_if, block, kind_of: Proc)
+end
+
+
+# Chef event_handler to hook into when disabling
+# @since 0.5.0
+property :disable_event,
+  kind_of: String,
+  default: 'converge_complete'
+
+# When compile_time is defined, apply the action immediately and then set the
+# action :nothing to ensure that it does not run a second time.
+def after_created
+  if compile_time
+    actions = Array(self.action) || [:manage]
+    actions.each do |action|
+      next if action == :nothing
+      self.run_action(:manage)
+    end
+    self.action(:nothing)
+  end
+end
+
+# Action to create the maintenance mode lock file
+# @since 0.5.0
+action :create do
+  maintenance_file_resource do
+    action :create_if_missing
+    only_if new_resource.enable_only_if if new_resource.enable_only_if
+  end
+end
+
+# Action to delete the maintenance mode lock file
+# @since 0.5.0
+action :delete do
+  maintenance_file_resource do
+    action :delete
+    only_if new_resource.disable_only_if if new_resource.disable_only_if
+  end
+end
+
+# Action to create the maintenance mode based on Chef event_handlers.
+action :manage do
+  new_resource = self
+
+  Chef.event_handler do
+    on new_resource.enable_event.to_sym do
+      if new_resource.guard_evaluates_true?(new_resource.enable_only_if)
+        ::File.write(new_resource.path, '')
+      end
+
+      if ::File.exist?(new_resource.path)
+        Chef::Log.warn "Nginx maintenance is currently in effect"
+      end
+    end if new_resource.enable_event
+
+    on new_resource.disable_event.to_sym do
+      if new_resource.guard_evaluates_true?(new_resource.disable_only_if)
+        ::File.rm(new_resource.path)
+      end
+
+      if ::File.exist?(new_resource.path)
+        Chef::Log.warn "Nginx maintenance is currently in effect"
+      end
+    end if new_resource.disable_event
+  end
+end
+
+action_class do
+  # Support whyrun
+  def whyrun_supported?
+    true
+  end
+
+	def maintenance_file_resource
+    file new_resource.path do
+      action :nothing
+    end
+	end
+
+  def guard_evaluates_true?(guard)
+    node = Chef.run_context.node
+    new_resource = new_resource
+    guard ? guard.call : true
+	end
+end

--- a/resources/maintenance.rb
+++ b/resources/maintenance.rb
@@ -1,5 +1,5 @@
-# Maintenance resource is designed to enable/disable maintenance mode on the 
-# instance. It also provides facilities to force maintenance mode for the 
+# Maintenance resource is designed to enable/disable maintenance mode on the
+# instance. It also provides facilities to force maintenance mode for the
 # duration of a Chef run.
 #
 # @example
@@ -23,7 +23,7 @@ resource_name :nginx_resources_maintenance
 property :path,
   kind_of: String,
   default: lazy {
-    node['nginx_resources']['health']['config']['maintenace_override']
+    node['nginx_resources']['health']['config']['maintenance_override']
   }
 
 # Whether to apply the resource at compile time
@@ -42,14 +42,13 @@ end
 # @since 0.5.0
 property :enable_event,
   kind_of: String,
-  default: "converge_start"
+  default: 'converge_start'
 
 # Condition to determine whether to disable maintenance mode
 # @since 0.5.0
 def disable_only_if(&block)
   set_or_return(:disable_only_if, block, kind_of: Proc)
 end
-
 
 # Chef event_handler to hook into when disabling
 # @since 0.5.0
@@ -99,7 +98,7 @@ action :manage do
       end
 
       if ::File.exist?(new_resource.path)
-        Chef::Log.warn "Nginx maintenance is currently in effect"
+        Chef::Log.warn 'Nginx maintenance is currently in effect'
       end
     end if new_resource.enable_event
 
@@ -109,7 +108,7 @@ action :manage do
       end
 
       if ::File.exist?(new_resource.path)
-        Chef::Log.warn "Nginx maintenance is currently in effect"
+        Chef::Log.warn 'Nginx maintenance is currently in effect'
       end
     end if new_resource.disable_event
   end
@@ -121,15 +120,15 @@ action_class do
     true
   end
 
-	def maintenance_file_resource
+  def maintenance_file_resource
     file new_resource.path do
       action :nothing
     end
-	end
+  end
 
   def guard_evaluates_true?(guard)
     node = Chef.run_context.node
     new_resource = new_resource
     guard ? guard.call : true
-	end
+  end
 end


### PR DESCRIPTION
This PR adds nginx_resources_maintenance to automatically manage maintenance mode at the beginning / end of a chef run.
